### PR TITLE
Remove project name parameter due to dead IFTTT integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ I want to track the time I spend building kites so I understand how much I am ch
 Architecture:
 ```
 Manually trigger processes via voice
-+------------------+              +---------+
-|                  |              |         |
-| Google Assistant +------------->+  IFTTT  |
-|                  |              |         |
-+------------------+              +----+----+
++------------------+
+|                  |
+| Google Assistant +-------------------+
+|                  |                   |
++------------------+                   |
                                        |
                                        | Make POST requests
-                                       | to the script
-                                       v
-                                +------+-----+               +---------------+
+                                       v to the script
+
+                                +------------+               +---------------+
                                 |            |               |               |
                                 | App Script +-------------->+ Google Sheets |
                                 |            |               |               |
@@ -46,8 +46,7 @@ Creates a new spreadsheet tab (sheet)
 with payload
 ```json
 {
-    "passcode": "secretString",
-    "projectName": "new project name",
+    "passcode": "secretString"
 }
 ```
 
@@ -59,8 +58,7 @@ Logs a start time for the relevant project in the spreadsheet
 with payload
 ```json
 {
-    "passcode": "secretString",
-    "projectName": "project name",
+    "passcode": "secretString"
 }
 ```
 
@@ -72,8 +70,7 @@ Logs an end time for the relevant project in the spreadsheet
 with payload
 ```json
 {
-    "passcode": "secretString",
-    "projectName": "project name",
+    "passcode": "secretString"
 }
 ```
 
@@ -85,8 +82,7 @@ Updates the project's sheet name to show that it is completed. This allows a new
 with payload
 ```json
 {
-    "passcode": "secretString",
-    "projectName": "project name",
+    "passcode": "secretString"
 }
 ```
 
@@ -94,8 +90,3 @@ with payload
 https://docs.google.com/spreadsheets/d/1qjZjHGqGeOq7pv1ohsgupzh05Y_NsyTA5gAmJr7-cy8/edit#gid=0 (No you can't have access. This link is for my benefit not yours.)
 
 Google Sheets serves as the storage for logs and for storing start/end times.
-
-### IFTTT
-http://ifttt.com
-
-IFTTT is used as the intermediary between 3rd party services (Google Assistant) and my script. Here I have applets set up to intercept Google Assistant queries and send network requests to my script.

--- a/src/actions/__tests__/completeProject.test.js
+++ b/src/actions/__tests__/completeProject.test.js
@@ -1,5 +1,5 @@
 import MockDate from 'mockdate';
-import { createMockSheet, createMockSpreadsheet } from '../../../testUtils/sheet';
+import { createMockSheet } from '../../../testUtils/sheet';
 import getSpreadsheet from '../../globals/Spreadsheet';
 import completeProject from '../completeProject';
 
@@ -12,19 +12,22 @@ describe('completeProject', () => {
         MockDate.set('2019-11-24T10:00:00.000Z');
         mockSheet = createMockSheet([[]]);
         getSpreadsheet.mockReturnValue({
-            getSheetByName: jest.fn(() => mockSheet),
+            getSheets: jest.fn(() => [null, mockSheet]),
         });
     });
     it('marks the project as complete', () => {
         expect.assertions(1);
-        completeProject('test');
-        expect(mockSheet.setName).toHaveBeenCalledWith('test - Completed 2019/11/24 02:00:00 am');
+        completeProject();
+        expect(mockSheet.setName).toHaveBeenCalledWith(
+            'test name - Completed 2019/11/24 02:00:00 am'
+        );
     });
-    it('throws if the sheet does not exist', () => {
+    it('throws if the project was already completed', () => {
         expect.assertions(1);
-        mockSheet = createMockSpreadsheet();
-        getSpreadsheet.mockReturnValue(mockSheet);
+        mockSheet.getName.mockReturnValue('test name - Completed');
 
-        expect(() => completeProject('test')).toThrow();
+        expect(() => completeProject()).toThrow(
+            'Could not complete project named "test name - Completed" because it is already completed.'
+        );
     });
 });

--- a/src/actions/__tests__/createProject.test.js
+++ b/src/actions/__tests__/createProject.test.js
@@ -1,4 +1,4 @@
-import { createMockSpreadsheet } from '../../../testUtils/sheet';
+import { createMockSpreadsheet, createMockSheet } from '../../../testUtils/sheet';
 import getSpreadsheet from '../../globals/Spreadsheet';
 import createProject from '../createProject';
 
@@ -13,19 +13,33 @@ describe('createProject', () => {
     });
     it('creates a new sheet with the template', () => {
         expect.assertions(1);
-        createProject('test');
-        expect(mockSpreadsheet.getData().test).toEqual([
+        createProject();
+        expect(mockSpreadsheet.getData()[1]).toEqual([
             ['Start time', 'End time', 'Elapsed time', 'Total Time:', '=SUM(C:C)'],
         ]);
     });
 
-    it('throws if a sheet already exists', () => {
+    it('creates a new sheet with the template even if there is an existing completed project', () => {
         expect.assertions(1);
         mockSpreadsheet = createMockSpreadsheet({
-            test: [],
+            1: createMockSheet([[]], { name: 'test - Completed' }),
+        });
+        getSpreadsheet.mockReturnValue(mockSpreadsheet);
+        createProject();
+        expect(mockSpreadsheet.getData()[1]).toEqual([
+            ['Start time', 'End time', 'Elapsed time', 'Total Time:', '=SUM(C:C)'],
+        ]);
+    });
+
+    it('throws if there is an incomplete project', () => {
+        expect.assertions(1);
+        mockSpreadsheet = createMockSpreadsheet({
+            1: createMockSheet([[]], { name: 'test' }),
         });
         getSpreadsheet.mockReturnValue(mockSpreadsheet);
 
-        expect(() => createProject('test')).toThrow();
+        expect(() => createProject('test')).toThrow(
+            'Project test is not yet completed. Complete that project before starting a new one.'
+        );
     });
 });

--- a/src/actions/__tests__/startProject.test.js
+++ b/src/actions/__tests__/startProject.test.js
@@ -1,5 +1,5 @@
 import MockDate from 'mockdate';
-import { createMockSpreadsheet } from '../../../testUtils/sheet';
+import { createMockSpreadsheet, createMockSheet } from '../../../testUtils/sheet';
 import getSpreadsheet from '../../globals/Spreadsheet';
 import startProject from '../startProject';
 
@@ -11,39 +11,51 @@ describe('startProject', () => {
     beforeEach(() => {
         MockDate.set('2019-11-24T10:00:00.000Z');
         mockSpreadsheet = createMockSpreadsheet({
-            test: [
+            1: createMockSheet([
                 ['Start time', 'Stop time', 'Elapsed', 'Total', 'whatever'],
                 [null, null, null],
-            ],
+            ]),
         });
         getSpreadsheet.mockReturnValue(mockSpreadsheet);
     });
     it('adds a new start time to the sheet', () => {
         expect.assertions(1);
-        startProject('test');
-        expect(mockSpreadsheet.getData().test).toEqual([
+        startProject();
+        expect(mockSpreadsheet.getData()[1].getData()).toEqual([
             ['Start time', 'Stop time', 'Elapsed', 'Total', 'whatever'],
             [new Date('2019-11-24T10:00:00.000Z'), null, null],
         ]);
     });
-    it('throws if the sheet does not exist', () => {
+    it('throws if the project has been completed', () => {
         expect.assertions(1);
-        mockSpreadsheet = createMockSpreadsheet();
+        mockSpreadsheet = createMockSpreadsheet({
+            1: createMockSheet(
+                [
+                    ['Start time', 'Stop time', 'Elapsed', 'Total', 'whatever'],
+                    [null, null, null],
+                ],
+                { name: 'test - Completed' }
+            ),
+        });
         getSpreadsheet.mockReturnValue(mockSpreadsheet);
 
-        expect(() => startProject('test')).toThrow();
+        expect(() => startProject('test')).toThrow(
+            'Could not start project named "test - Completed" because it has already been completed.'
+        );
     });
     it("throws if the previous timer hasn't been stopped", () => {
         expect.assertions(1);
         mockSpreadsheet = createMockSpreadsheet({
-            test: [
+            1: createMockSheet([
                 ['Start time', 'Stop time', 'Elapsed', 'Total', 'whatever'],
                 [new Date('2019-11-24T10:00:00.000Z'), null, null],
                 [null, null, null],
-            ],
+            ]),
         });
         getSpreadsheet.mockReturnValue(mockSpreadsheet);
 
-        expect(() => startProject('test')).toThrow();
+        expect(() => startProject('test')).toThrow(
+            'Could not start project named "test name" because it has not been stopped.'
+        );
     });
 });

--- a/src/actions/__tests__/stopProject.test.js
+++ b/src/actions/__tests__/stopProject.test.js
@@ -1,5 +1,5 @@
 import MockDate from 'mockdate';
-import { createMockSpreadsheet } from '../../../testUtils/sheet';
+import { createMockSpreadsheet, createMockSheet } from '../../../testUtils/sheet';
 import getSpreadsheet from '../../globals/Spreadsheet';
 import stopProject from '../stopProject';
 
@@ -11,38 +11,33 @@ describe('stopProject', () => {
     beforeEach(() => {
         MockDate.set('2019-11-24T10:00:00.000Z');
         mockSpreadsheet = createMockSpreadsheet({
-            test: [
+            1: createMockSheet([
                 ['Start time', 'Stop time', 'Elapsed', 'Total', 'whatever'],
                 [new Date('2019-11-23T10:00:00.000Z'), null, null],
-            ],
+            ]),
         });
         getSpreadsheet.mockReturnValue(mockSpreadsheet);
     });
     it('adds a new stop time to the sheet', () => {
         expect.assertions(1);
-        stopProject('test');
-        expect(mockSpreadsheet.getData().test).toEqual([
+        stopProject();
+        expect(mockSpreadsheet.getData()[1].getData()).toEqual([
             ['Start time', 'Stop time', 'Elapsed', 'Total', 'whatever'],
             [new Date('2019-11-23T10:00:00.000Z'), new Date('2019-11-24T10:00:00.000Z'), '=B2-A2'],
         ]);
     });
-    it('throws if the sheet does not exist', () => {
-        expect.assertions(1);
-        mockSpreadsheet = createMockSpreadsheet();
-        getSpreadsheet.mockReturnValue(mockSpreadsheet);
-
-        expect(() => stopProject('test')).toThrow();
-    });
     it("throws if the timer hasn't been started", () => {
         expect.assertions(1);
         mockSpreadsheet = createMockSpreadsheet({
-            test: [
+            1: createMockSheet([
                 ['Start time', 'Stop time', 'Elapsed', 'Total', 'whatever'],
                 [null, null, null],
-            ],
+            ]),
         });
         getSpreadsheet.mockReturnValue(mockSpreadsheet);
 
-        expect(() => stopProject('test')).toThrow();
+        expect(() => stopProject()).toThrow(
+            'Could not stop project named "test name" because it has not been started.'
+        );
     });
 });

--- a/src/actions/completeProject.js
+++ b/src/actions/completeProject.js
@@ -9,19 +9,21 @@ import getSpreadsheet from '../globals/Spreadsheet';
  *
  * @param  {String} projectName
  */
-export default function createProject(projectName) {
-    log(`Completing project named "${projectName}"`);
-
+export default function completeProject() {
     // Get the spreadsheet
     const spreadsheet = getSpreadsheet();
-    const sheet = spreadsheet.getSheetByName(projectName);
+
+    // Always getting the second sheet since that's where we put it on createProject
+    const sheet = spreadsheet.getSheets()[1];
+    const sheetName = sheet.getName();
+    log(`Completing project named "${sheetName}"`);
 
     // Can't complete a project that doesn't exist
-    if (sheet == null) {
+    if (sheetName.includes('Completed')) {
         throw new Error(
-            `Could not complete project named "${projectName}" because it does not exist.`
+            `Could not complete project named "${sheetName}" because it is already completed.`
         );
     }
 
-    sheet.setName(`${projectName} - Completed ${moment().format('YYYY/MM/DD hh:mm:ss a')}`);
+    sheet.setName(`${sheetName} - Completed ${moment().format('YYYY/MM/DD hh:mm:ss a')}`);
 }

--- a/src/actions/createProject.js
+++ b/src/actions/createProject.js
@@ -9,20 +9,26 @@ import getSpreadsheet from '../globals/Spreadsheet';
  *
  * @param  {String} projectName
  */
-export default function createProject(projectName) {
-    log(`Creating project named "${projectName}"`);
+export default function createProject() {
+    const defaultProjectName = `Project-${new Date().toLocaleDateString()}`;
+    log(`Creating project named "${defaultProjectName}"`);
 
     // Get the spreadsheet
     const spreadsheet = getSpreadsheet();
-    const existingSheet = spreadsheet.getSheetByName(projectName);
+    const existingSheet = spreadsheet.getSheets()[1];
+    if (existingSheet) {
+        const existingSheetName = existingSheet.getName();
 
-    // Can't create the sheet if one already exists
-    if (existingSheet !== null) {
-        throw new Error(`A project named "${projectName}" already exists`);
+        if (!existingSheetName.includes('Completed')) {
+            throw new Error(
+                `Project ${existingSheetName} is not yet completed. Complete that project before starting a new one.`
+            );
+        }
     }
 
-    // Create the sheet with the project name
-    const sheet = spreadsheet.insertSheet(projectName);
+    // Create the sheet with the default project name
+    // Insert the sheet as the second sheet, right behind Logs
+    const sheet = spreadsheet.insertSheet(defaultProjectName, 1);
 
     // Add a heading row with a forumula for calculating total time.
     // The total time is in the top row to prevent interfering with automated

--- a/src/actions/startProject.js
+++ b/src/actions/startProject.js
@@ -1,16 +1,18 @@
 import log from '../util/log';
 import getSpreadsheet from '../globals/Spreadsheet';
 
-export default function startProject(projectName) {
-    log(`Starting project named "${projectName}"`);
-
+export default function startProject() {
     // Get the spreadsheet
     const spreadsheet = getSpreadsheet();
-    const sheet = spreadsheet.getSheetByName(projectName);
+    const sheet = spreadsheet.getSheets()[1];
+    const projectName = sheet.getName();
+    log(`Starting project named "${projectName}"`);
 
-    // Throw if a tab with the provided project name doesn't exist
-    if (sheet == null) {
-        throw new Error(`Could not start project named "${projectName}" because it does not exist`);
+    // Throw if the project has alredy been completed
+    if (projectName.includes('Completed')) {
+        throw new Error(
+            `Could not start project named "${projectName}" because it has already been completed.`
+        );
     }
 
     // Get the last row (lowest row with content in it) to determine where to

--- a/src/actions/stopProject.js
+++ b/src/actions/stopProject.js
@@ -1,17 +1,12 @@
 import log from '../util/log';
 import getSpreadsheet from '../globals/Spreadsheet';
 
-export default function stopProject(projectName) {
-    log(`Stopping project named "${projectName}"`);
-
+export default function stopProject() {
     // Get the spreadsheet
     const spreadsheet = getSpreadsheet();
-    const sheet = spreadsheet.getSheetByName(projectName);
-
-    // Throw if the sheet doesn't exist
-    if (sheet == null) {
-        throw new Error(`Could not stop project named "${projectName}" because it does not exist`);
-    }
+    const sheet = spreadsheet.getSheets()[1];
+    const projectName = sheet.getName();
+    log(`Stopping project named "${projectName}"`);
 
     // Get the last row (lowest row with content in it) to determine where to
     // put the new stop entry

--- a/src/router.js
+++ b/src/router.js
@@ -13,13 +13,13 @@ export default function route(request, method) {
     if (method === 'post') {
         switch (request.action) {
             case 'start':
-                return startProject(request.payload.projectName);
+                return startProject();
             case 'stop':
-                return stopProject(request.payload.projectName);
+                return stopProject();
             case 'create':
-                return createProject(request.payload.projectName);
+                return createProject();
             case 'complete':
-                return completeProject(request.payload.projectName);
+                return completeProject();
             default:
                 return 'No route found';
         }

--- a/testUtils/sheet.js
+++ b/testUtils/sheet.js
@@ -3,13 +3,17 @@
 /**
  * Creates a mock sheet from the provided rectangular array data.
  */
-export function createMockSheet(data, numberFormat = null) {
+export function createMockSheet(data, { numberFormat = null, name = 'test name' } = {}) {
     if (!data) {
         return null;
     }
     return {
+        getData() {
+            return data;
+        },
         setName: jest.fn(),
         numberFormat,
+        getName: jest.fn().mockReturnValue(name),
         getLastRow() {
             return data.reduce((lastRow, row, index) => {
                 if (row.find(cell => !!cell)) {
@@ -57,7 +61,7 @@ export function createMockSheet(data, numberFormat = null) {
                     return createMockSheet(updatedData);
                 },
                 setNumberFormat(updatedFormat) {
-                    return createMockSheet(data, updatedFormat);
+                    return createMockSheet(data, { numberFormat: updatedFormat });
                 },
             };
         },
@@ -73,12 +77,12 @@ export function createMockSpreadsheet(overrides = {}) {
         ...overrides,
     };
     return {
-        getSheetByName(name) {
-            return createMockSheet(data[name]);
+        getSheets() {
+            return data;
         },
-        insertSheet(name) {
-            data[name] = [];
-            return createMockSheet(data[name]);
+        insertSheet(name, index) {
+            data[index] = [];
+            return createMockSheet(data[index]);
         },
         getData() {
             return data;


### PR DESCRIPTION
The Google Assistant integration for IFTTT got replaced with hot garbage that doesn't support any sort of variable within google assistant commands. So, IFTTT no longer offers anything that I care about, so I cancelled my subscription. There appears to be no other way to provide variables in custom commands to Google Assistant, so I'm updating this to no longer take project name as a variable. Instead, there can only be one ongoing project at a time. It's annoying, but it's better than nothing.